### PR TITLE
Fix a compilation error and a fallthrough warning

### DIFF
--- a/src/modcan.c
+++ b/src/modcan.c
@@ -33,6 +33,7 @@
 #include "py/mphal.h"
 #include "py/mperrno.h"
 #include "mpconfigport.h"
+#include "freertos/idf_additions.h"
 #include "freertos/task.h"
 #include "esp_idf_version.h"
 

--- a/src/modcan.c
+++ b/src/modcan.c
@@ -325,6 +325,7 @@ static mp_obj_t esp32_hw_can_init_helper(esp32_can_obj_t *self, size_t n_args, c
                 .tseg_2 = args[ARG_bs2].u_int,
                 .triple_sampling = false
             });
+            break;
 
         #ifdef TWAI_TIMING_CONFIG_1KBITS
         case 1000:


### PR DESCRIPTION
Hi, thanks for the module code.

Trying to build it with idf v5.4 and current micropython resulted in an error and a warning. The fixes were quite simple fortunately, please see the commits.